### PR TITLE
DP-2201 Remove python-base-layer dependency

### DIFF
--- a/serverless/functions/connection_manager.yaml
+++ b/serverless/functions/connection_manager.yaml
@@ -8,6 +8,3 @@ events:
           webhook_token: false
   - websocket:
       route: $disconnect
-layers:
-  - ${ssm:/dataplatform/shared/python-base-layer-arn}
-

--- a/serverless/functions/publish_event.yaml
+++ b/serverless/functions/publish_event.yaml
@@ -1,3 +1,1 @@
 handler: event_data_subscription.publish_event.handle
-layers:
-  - ${ssm:/dataplatform/shared/python-base-layer-arn}


### PR DESCRIPTION
This was actually ported from dataplatform-common-python to okdata-aws in 8087eeaa1345c44fffad57697f73c9c50554a264, but the layer dependency remained.